### PR TITLE
klee updates

### DIFF
--- a/internal/characters/klee/asc.go
+++ b/internal/characters/klee/asc.go
@@ -8,18 +8,20 @@ import (
 )
 
 const (
-	a1IcdKey             = "a1-icd"
-	a1SparkKey           = "a1-spark"
-	boomboosterBurstKey  = "boombooster-burst"
-	boomboosterNormalKey = "boombooster-normal"
-	boomboosterSkillKey  = "boomboster-skill"
+	a1IcdKey           = "a1-icd"
+	a1SparkKey         = "a1-spark"
+	boomBadgeBurstKey  = "boombadge-burst"
+	boomBadgeNormalKey = "boombadge-normal"
+	boomBadgeSkillKey  = "boombadge-skill"
 )
 
 // When Jumpy Dumpty and Normal Attacks deal DMG, Klee has a 50% chance to obtain an Explosive Spark.
 // This Explosive Spark is consumed by the next Charged Attack, which costs no Stamina and deals 50% increased DMG.
 
 // Magic bonus:
-// Using her Elemental Skill or Elemental Burst grants an additional Explosive Spark. Max 3 Explosive Sparks.
+// Using her Elemental Skill Jumpy Dumpty or Elemental Burst Sparks 'n' Splash also grants 1 Explosive Spark.
+// Klee can hold up to 3 Explosive Sparks. While holding an Explosive Spark, Klee's Charged Attack will consume
+// 1 Spark to perform a special stamina-free Charged Attack, Boom-Boom Strike, dealing 50% increased DMG.
 func (c *char) makeA1CB() info.AttackCBFunc {
 	if c.Base.Ascension < 1 {
 		return nil
@@ -90,9 +92,9 @@ func (c *char) getMagicCount() int {
 }
 
 // Magic: Secret Rite
-// Each time Klee deals DMG with her Elemental Skill, Elemental Burst, or Normal Attack, she gains a stack of Boom Booster.
-// Each stack lasts for 20s and has its own independent timer. While Klee has 1/2/3 stacks, her Explosive Spark-enhanced
-// Charged Attacks deal 115%/130%/150% of their original DMG.
+// When Klee deals DMG with Normal Attacks, Elemental Skill, or Elemental Burst, she gains 1 Boom Badge, lasting 20s.
+// Each type of attack can grant at most 1 Boom Badge this way, and each badge has its own independent timer.
+// While Klee has 1/2/3 Boom Badges, her special Charged Attack Boom-Boom Strike deals 115%/130%/150% of its original DMG.
 func (c *char) magicInit() {
 	if !c.IsMagic {
 		return
@@ -112,15 +114,15 @@ func (c *char) magicInit() {
 
 		switch atk.Info.AttackTag {
 		case attacks.AttackTagNormal:
-			c.AddStatus(boomboosterNormalKey, 60*20, true)
+			c.AddStatus(boomBadgeNormalKey, 60*20, true)
 		case attacks.AttackTagElementalArt:
-			c.AddStatus(boomboosterSkillKey, 60*20, true)
+			c.AddStatus(boomBadgeSkillKey, 60*20, true)
 		case attacks.AttackTagElementalBurst:
-			c.AddStatus(boomboosterBurstKey, 60*20, true)
+			c.AddStatus(boomBadgeBurstKey, 60*20, true)
 		default:
 			return false
 		}
 
 		return false
-	}, "klee-boombooster")
+	}, "klee-boombadge")
 }

--- a/internal/characters/klee/attack.go
+++ b/internal/characters/klee/attack.go
@@ -122,8 +122,7 @@ func (c *char) Attack(p map[string]int) (action.Info, error) {
 
 	// Magic: Secret Rite
 	// When she performs the third Normal Attack in the sequence, an Explosive Spark
-	// will be consumed to unleash Coordinated Charged Attack: Blast.
-	// TODO: delay?
+	// will be consumed to unleash an additional attack equivalent to Boom-Boom Strike.
 	if c.IsMagic && c.getMagicCount() > 1 && c.StatusIsActive(a1SparkKey) {
 		if c.NormalCounter == 2 || c.Base.Cons == 6 && c.NormalCounter < 2 && c.Core.Rand.Float64() < 0.4 {
 			c.queueCoordinatedCharge()
@@ -171,13 +170,13 @@ func (c *char) Attack(p map[string]int) (action.Info, error) {
 }
 
 func (c *char) queueCoordinatedCharge() {
-	delay := 50 // TODO: Proper delay
+	delay := 30
 	travel := 10
 
 	c.Core.Tasks.Add(func() {
 		ai := c.getChargeAttackInfo()
-		ai.Abil = "Coordinated Charge Attack: Blast"
-		snap := c.applySpark(ai)
+		snap := c.applySpark(&ai)
+		ai.Abil += " (Coordinated)"
 		c.Core.QueueAttackWithSnap(
 			ai,
 			snap,

--- a/internal/characters/klee/charge.go
+++ b/internal/characters/klee/charge.go
@@ -16,8 +16,8 @@ const (
 )
 
 var (
-	boomboosterMult = []float64{1, 1.15, 1.3, 1.5}
-	chargeFrames    []int
+	boombadgeMult = []float64{1, 1.15, 1.3, 1.5}
+	chargeFrames  []int
 )
 
 func init() {
@@ -48,7 +48,7 @@ func (c *char) ChargeAttack(p map[string]int) (action.Info, error) {
 
 	c.Core.Tasks.Add(func() {
 		ai := c.getChargeAttackInfo()
-		snap := c.applySpark(ai)
+		snap := c.applySpark(&ai)
 		c.Core.QueueAttackWithSnap(
 			ai,
 			snap,
@@ -68,9 +68,10 @@ func (c *char) ChargeAttack(p map[string]int) (action.Info, error) {
 	}, nil
 }
 
-func (c *char) applySpark(ai info.AttackInfo) info.Snapshot {
-	snap := c.Snapshot(&ai)
+func (c *char) applySpark(ai *info.AttackInfo) info.Snapshot {
+	snap := c.Snapshot(ai)
 	if c.StatusIsActive(a1SparkKey) {
+		ai.Abil = "Boom-Boom Strike"
 		snap.Stats[attributes.DmgP] += .50
 		// Magic bonus (C6):
 		// When Klee uses an Explosive Spark, there is a 50% chance it will not be consumed.
@@ -81,7 +82,7 @@ func (c *char) applySpark(ai info.AttackInfo) info.Snapshot {
 		c.Core.Log.NewEvent("consuming spark", glog.LogCharacterEvent, c.Index()).
 			Write("previous spark stacks", previous).
 			Write("new spark stacks", c.a1CurrentStack).
-			Write("boombooster mult", c.getBoomBoosterMult())
+			Write("boombadge mult", c.getBoomBadgeMult())
 		if c.a1CurrentStack == 0 {
 			c.DeleteStatus(a1SparkKey)
 		}
@@ -89,26 +90,26 @@ func (c *char) applySpark(ai info.AttackInfo) info.Snapshot {
 	return snap
 }
 
-func (c *char) getBoomBoosterStacks() int {
+func (c *char) getBoomBadgeStacks() int {
 	count := 0
-	if c.StatusIsActive(boomboosterNormalKey) {
+	if c.StatusIsActive(boomBadgeNormalKey) {
 		count++
 	}
-	if c.StatusIsActive(boomboosterSkillKey) {
+	if c.StatusIsActive(boomBadgeSkillKey) {
 		count++
 	}
-	if c.StatusIsActive(boomboosterBurstKey) {
+	if c.StatusIsActive(boomBadgeBurstKey) {
 		count++
 	}
 	return count
 }
 
-// TODO: Is boombooster applied on snapshot?
-func (c *char) getBoomBoosterMult() float64 {
+// TODO: Is boombadge applied on snapshot?
+func (c *char) getBoomBadgeMult() float64 {
 	if !c.StatusIsActive(a1SparkKey) {
 		return 1.0
 	}
-	return boomboosterMult[c.getBoomBoosterStacks()]
+	return boombadgeMult[c.getBoomBadgeStacks()]
 }
 
 func (c *char) getChargeAttackInfo() info.AttackInfo {
@@ -122,7 +123,7 @@ func (c *char) getChargeAttackInfo() info.AttackInfo {
 		PoiseDMG:   180,
 		Element:    attributes.Pyro,
 		Durability: 25,
-		Mult:       charge[c.TalentLvlAttack()] * c.getBoomBoosterMult(),
+		Mult:       charge[c.TalentLvlAttack()] * c.getBoomBadgeMult(),
 	}
 	return ai
 }


### PR DESCRIPTION
- rename boombooster to boombadge
- change coordinated CA delay to 40f total
- rename spark boosted CAs to Boom-Boom Strike