### PR TITLE
Remove crystallize GCD check from LCr

### DIFF
--- a/pkg/reactable/lunarcrystallize.go
+++ b/pkg/reactable/lunarcrystallize.go
@@ -30,9 +30,6 @@ func (r *Reactable) TryLunarCrystallize(a *info.AttackEvent) bool {
 	if a.Info.Durability < info.ZeroDur {
 		return false
 	}
-	if r.crystallizeGCD != -1 && r.core.F < r.crystallizeGCD {
-		return false
-	}
 
 	if r.core.Status.Duration(LcrKey) > 0 {
 		r.extendLunarCrystallizeConstructDur()


### PR DESCRIPTION
LCr reaction is not gated by the global crystallize CD, it is a different reaction.