### PR TITLE
Re-implement Albedo snapshotting

### DIFF
--- a/internal/characters/albedo/albedo.go
+++ b/internal/characters/albedo/albedo.go
@@ -20,6 +20,7 @@ type char struct {
 	skillActive     bool
 	skillArea       info.AttackPattern
 	skillAttackInfo info.AttackInfo
+	skillSnapshot   info.Snapshot
 	// hexerei
 	aureliths      [2]int
 	oldestAurelith int

--- a/internal/characters/albedo/asc.go
+++ b/internal/characters/albedo/asc.go
@@ -105,9 +105,6 @@ func (c *char) getAureliths() int {
 }
 
 func (c *char) createAurelith() {
-	if c.getAureliths() >= 2 {
-		return
-	}
 	if c.Core.Flags.LogDebug {
 		c.Core.Log.NewEventBuildMsg(glog.LogCharacterEvent, c.Index(), "Creating aurelith").Write("expires", c.Core.F+10*60)
 	}

--- a/internal/characters/albedo/skill.go
+++ b/internal/characters/albedo/skill.go
@@ -59,6 +59,7 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 	ai.Mult = skillTick[c.TalentLvlSkill()]
 	ai.UseDef = true
 	c.skillAttackInfo = ai
+	c.skillSnapshot = c.Snapshot(&c.skillAttackInfo)
 
 	// create a construct
 	// Construct is not fully formed until after the hit lands (exact timing unknown)
@@ -127,10 +128,10 @@ func (c *char) skillHook() {
 		// this ICD is most likely tied to the construct, so it's not hitlag extendable
 		c.AddStatus(skillICDKey, 120, false) // proc every 2s
 
-		c.Core.QueueAttack(
+		c.Core.QueueAttackWithSnap(
 			c.skillAttackInfo,
+			c.skillSnapshot,
 			combat.NewCircleHitOnTarget(trg, nil, 3.4),
-			1,
 			1,
 			c.particleCB,
 		)


### PR DESCRIPTION
Albedo's snapshotting implementation was removed in error - his Solar Isotoma still snapshots just fine. The likely source of the early belief that he no longer snapshots is that the hexerei A1 240% MV is a fully dynamic quill.

Also, the limitation on not generating a new Silver Isotoma if there are already 2 is not technically accurate - _every hit_ (while within the 20s window) will generate a Silver Isotoma, replacing the oldest one.

There's technically further snapshotting mechanisms on the Silver Isotoma themselves, but this is only ever relevant if the solar isotoma gets destroyed, which this sim does not account for, so it's not important to implement.