### PR TITLE
Correct the crystallize reaction durability calculation

### DIFF
--- a/pkg/reactable/crystallize.go
+++ b/pkg/reactable/crystallize.go
@@ -64,9 +64,9 @@ func (r *Reactable) tryCrystallizeWithEle(a *info.AttackEvent, ele attributes.El
 	char := r.core.Player.ByIndex(a.Info.ActorIndex)
 	r.addCrystallizeShard(char, rt, ele, r.core.F)
 	// reduce
-	r.reduce(ele, a.Info.Durability, 0.5)
-	// TODO: confirm u can only crystallize once
-	a.Info.Durability = 0
+	consumed := r.reduce(ele, a.Info.Durability, 0.5)
+	a.Info.Durability -= consumed
+	a.Info.Durability = max(a.Info.Durability, 0)
 	a.Reacted = true
 	// event
 	r.core.Events.Emit(evt, r.self, a)

--- a/pkg/reactable/lunarcrystallize.go
+++ b/pkg/reactable/lunarcrystallize.go
@@ -53,9 +53,9 @@ func (r *Reactable) TryLunarCrystallize(a *info.AttackEvent) bool {
 	}
 
 	// reduce
-	r.reduce(attributes.Hydro, a.Info.Durability, 0.5)
-	// TODO: confirm u can only lunar crystallize once
-	a.Info.Durability = 0
+	consumed := r.reduce(attributes.Hydro, a.Info.Durability, 0.5)
+	a.Info.Durability -= consumed
+	a.Info.Durability = max(a.Info.Durability, 0)
 	a.Reacted = true
 
 	// event


### PR DESCRIPTION
Setting the durability of the applied geo to 0 was causing lunar crystallize procs to not happen even in situations where they should (1U geo on <0.5U electro and also a hydro aura), and the "confirm you can only crystallize once" safety net is redundant since there's already a separately implemented GCD check.